### PR TITLE
Fix partially matched `legend.position`

### DIFF
--- a/vignettes/dynamAedes_01_punctual.Rmd
+++ b/vignettes/dynamAedes_01_punctual.Rmd
@@ -192,7 +192,7 @@ geom_line(linewidth=0.8) +
 labs(x="Date", y="Interquantile range abundance", col="Stage", fill="Stage") +
 facet_wrap(~stage, scales = "free_y") +
 theme_light() +
-theme(legend.pos="bottom",  
+theme(legend.position="bottom",  
   text = element_text(size=16), 
   strip.text = element_text(face = "italic"))
 

--- a/vignettes/dynamAedes_02_local.Rmd
+++ b/vignettes/dynamAedes_02_local.Rmd
@@ -426,7 +426,7 @@ geom_line(linewidth=0.8) +
 labs(x="Date", y="Interquantile range abundance", col="Stage", fill="Stage") +
 facet_wrap(~stage, scales = "free_y") +
 theme_light() +
-theme(legend.pos="bottom",  
+theme(legend.position="bottom",  
   text = element_text(size=16), 
   strip.text = element_text(face = "italic"))
 ```

--- a/vignettes/dynamAedes_03_regional.Rmd
+++ b/vignettes/dynamAedes_03_regional.Rmd
@@ -279,7 +279,7 @@ geom_line(linewidth=0.8) +
 labs(x="Date", y="Interquantile range abundance", col="Stage", fill="Stage") +
 facet_wrap(~stage, scales = "free_y") +
 theme_light() +
-theme(legend.pos="bottom",  
+theme(legend.position="bottom",  
   text = element_text(size=16), 
   strip.text = element_text(face = "italic"))
 ```

--- a/vignettes/dynamAedes_04_uncompModel.Rmd
+++ b/vignettes/dynamAedes_04_uncompModel.Rmd
@@ -203,7 +203,7 @@ geom_line(linewidth=0.8) +
 ylim(0,10)+
 labs(x="Date", y="Interquantile range abundance", col="Stage", fill="Stage") +
 theme_classic() +
-theme(legend.pos="bottom",  
+theme(legend.position="bottom",  
   text = element_text(size=16), 
   strip.text = element_text(face = "italic"))
 


### PR DESCRIPTION
Hello there,

We have been preparing a new release of ggplot2 and during a reverse dependency check, it became apparent that the prospective ggplot2 3.5.0 would break dynamAedes.

This PR updates a few partially matched `legend.position` arguments to the `theme()` function, which should fix check failures due to ggplot2's update.

To test the code changes with the release candidate, you can install it with the code below:

```r
remotes::install_github("tidyverse/ggplot2", ref = remotes::github_pull("5592"))
```

The release of ggplot2 3.5.0 is scheduled for the 12th of Februari. The progress of the release can be tracked in https://github.com/tidyverse/ggplot2/issues/5588. We hope that this PR might help dynamAedes get out a fix if necessary.